### PR TITLE
Add die use action

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -636,6 +636,11 @@
   },
   {
     "type": "item_action",
+    "id": "RPGDIE",
+    "name": "Roll die"
+  },
+  {
+    "type": "item_action",
     "id": "GASMASK",
     "name": "Prepare to use"
   },

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1347,7 +1347,8 @@
     "dispersion": 15,
     "loudness": 0,
     "count": 7,
-    "effects": [ "NEVER_MISFIRES" ]
+    "effects": [ "NEVER_MISFIRES" ],
+    "use_action": "RPGDIE"
   },
   {
     "type": "AMMO",
@@ -1368,6 +1369,7 @@
     "dispersion": 10,
     "loudness": 0,
     "count": 7,
-    "effects": [ "NEVER_MISFIRES" ]
+    "effects": [ "NEVER_MISFIRES" ],
+    "use_action": "RPGDIE"
   }
 ]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2691,6 +2691,11 @@ std::string item::info( std::vector<iteminfo> &info, const iteminfo_query *parts
                 }
             }
         }
+        if( this->get_var( "die_num_sides", 0 ) != 0 ) {
+            info.emplace_back( "DESCRIPTION",
+                               string_format( _( "* This item can be used as a <info>die</info>, and has %s sides." ),
+                                              static_cast<int>( this->get_var( "die_num_sides", 0 ) ) ) );
+        }
 
         // list recipes you could use it in
         itype_id tid;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -604,6 +604,7 @@ void Item_factory::init()
     add_iuse( "CHAINSAW_OFF", &iuse::chainsaw_off );
     add_iuse( "CHAINSAW_ON", &iuse::chainsaw_on );
     add_iuse( "CHEW", &iuse::chew );
+    add_iuse( "RPGDIE", &iuse::rpgdie );
     add_iuse( "BIRDFOOD", &iuse::feedbird );
     add_iuse( "BURROW", &iuse::burrow );
     add_iuse( "CHOP_TREE", &iuse::chop_tree );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4051,6 +4051,23 @@ int iuse::mp3_on( player *p, item *it, bool t, const tripoint &pos )
     return it->type->charges_to_use();
 }
 
+int iuse::rpgdie( player *you, item *die, bool, const tripoint & )
+{
+    const std::array<int, 6> sides_options = { 4, 6, 8, 10, 12, 20 };
+    int num_sides = die->get_var( "die_num_sides", 0 );
+    if( num_sides == 0 ) {
+        const int sides = sides_options[ rng( 0, 5 ) ];
+        num_sides = sides;
+        die->set_var( "die_num_sides", sides );
+    }
+    const int roll = rng( 1, num_sides );
+    you->add_msg_if_player( _( "You roll a %d on your %d sided %s" ), roll, num_sides, die->tname() );
+    if( roll == num_sides ) {
+        add_msg( m_good, _( "Critical!" ) );
+    }
+    return roll;
+}
+
 int iuse::dive_tank( player *p, item *it, bool t, const tripoint & )
 {
     if( t ) { // Normal use

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -133,6 +133,7 @@ class iuse
         int shocktonfa_on( player *, item *, bool, const tripoint & );
         int mp3( player *, item *, bool, const tripoint & );
         int mp3_on( player *, item *, bool, const tripoint & );
+        int rpgdie( player *, item *, bool, const tripoint & );
         int dive_tank( player *, item *, bool, const tripoint & );
         int gasmask( player *, item *, bool, const tripoint & );
         int portable_game( player *, item *, bool, const tripoint & );


### PR DESCRIPTION
This adds a die use action for the RPG die PR

Having either `count` or defining the `TYPE` as ammo will cause the whole stack to be set to be set to the same number of faces when one die in that stack is rolled.